### PR TITLE
Count number of open calls to ensure one does not clobber another

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -97,9 +97,17 @@ window.CD = {
   // internal, do not modify
   _readyToCapture: true,
 
+  _openCalls: 0,
+
+  _reset: function() {
+    CD._openCalls = 0;
+    CD._readyToCapture = true;
+  },
+
   suspend: function(maxSuspension) {
     maxSuspension = maxSuspension || 1000;
 
+    CD._openCalls++;
     CD._readyToCapture = false;
     if (typeof(MICapture) == 'undefined') {
       CD.log("suspended, will end in " + maxSuspension + " millis");
@@ -113,6 +121,13 @@ window.CD = {
   },
 
   capture: function() {
+    CD._openCalls--;
+
+    if(CD._openCalls > 0) {
+      CD.log("outstanding calls, not capturing");
+      return;
+    }
+
     CD._readyToCapture = true;
     if(typeof(MICapture) == 'undefined') {
       CD.log("now ready to capture");

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -72,13 +72,13 @@ test("CD.proxyUrl with https url", function() {
 });
 
 test("CD.suspend", function() {
-  CD.capture(); // clean out previous test
+  CD._reset(); // clean out previous test
   CD.suspend();
   equal(CD._readyToCapture, false, "sets readyToCapture");
 });
 
 test("CD.capture", function() {
-  CD.suspend(); // clean out previous test
+  CD._reset(); // clean out previous test
   CD.capture();
   equal(CD._readyToCapture, true, "sets readyToCapture");
 });
@@ -219,4 +219,21 @@ QUnit.test("CD.getCORS with POST", function(assert) {
   equal(requests[0].url, "http://cors.movableink.com/google.com/");
 
   xhr.restore();
+});
+
+QUnit.test("concurrent calls", function(assert) {
+  CD._reset();
+
+  CD.suspend(1000); // 1 open call
+  CD.suspend(500); // 2 open calls
+  CD.capture(); // 1 open call
+  CD.suspend(1000); // 2 open calls
+
+  CD.capture(); // 1 open call
+  equal(CD._readyToCapture, false, "waits for open calls to get to zero");
+  equal(CD._openCalls, 1, "one open call");
+
+  CD.capture(); // 0 open calls
+  equal(CD._readyToCapture, true, "sets readyToCapture");
+  equal(CD._openCalls, 0, "zero open calls");
 });


### PR DESCRIPTION
We should make sure that all concurrent calls have finished before cropping. Note that `CD._reset()` should only be used for tests.