### PR TITLE
update getImages() call to accept a callback that fires only once

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -185,7 +185,7 @@ window.CD = {
     var img = new Image();
     img.onload = function() {
       CD.capture();
-      callback(img);
+      if(callback) { callback(img); }
     };
     img.onerror = function() {
       CD.capture();
@@ -195,12 +195,14 @@ window.CD = {
     CD.suspend(options.maxSuspension);
   },
 
-  getImages: function(urls, options, callback) {
-    var args = Array.prototype.slice.call(arguments);
+  getImages: function(urls, options, callback, singleCallback) {
+    if(typeof(options) === "function") {
+      singleCallback = callback;
+      callback = options;
+      options = {};
+    }
 
-    callback = args.pop();
-    url = args[0];
-    options = args[1] || {};
+    options = options || {};
     options.maxSuspension = options.maxSuspension || 1000;
 
     var imagesLeft = urls.length;
@@ -233,7 +235,9 @@ window.CD = {
     function callbackNext() {
       var next = calledIndex + 1;
       if(imgs[next]) {
-        callback(imgs[next]);
+        if(singleCallback) {
+          singleCallback(imgs[next]);
+        }
         calledIndex = next;
         callbackNext();
       }
@@ -242,6 +246,9 @@ window.CD = {
     function finish() {
       if(imagesLeft == 0) {
         CD.capture();
+        if(callback) {
+          callback(imgs);
+        }
       }
     }
   },


### PR DESCRIPTION
Before, it was `getImages(urls, options, callback);` now it's `getImages(urls, options, callback, singleCallback);`. The `callback` gets called only once after all images have loaded; the `singleCallback` gets fired on each image load, similar to the previous behavior. The `callback` gets called with an argument that is an array of all of the instantiated `Image` objects.