### PR TITLE
remove the default maxSuspension timeouts

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -98,8 +98,6 @@ window.CD = {
   _readyToCapture: true,
 
   suspend: function(maxSuspension) {
-    maxSuspension = maxSuspension || 1000;
-
     CD._readyToCapture = false;
     if (typeof(MICapture) == 'undefined') {
       CD.log("suspended, will end in " + maxSuspension + " millis");
@@ -107,9 +105,11 @@ window.CD = {
       MICapture.begin();
     }
 
-    setTimeout(function() {
-      CD.capture();
-    }, maxSuspension);
+    if(maxSuspension) {
+      setTimeout(function() {
+        CD.capture();
+      }, maxSuspension);
+    }
   },
 
   capture: function() {
@@ -147,8 +147,6 @@ window.CD = {
     callback = args.pop();
     options = args[1] || {};
 
-    options.maxSuspension = options.maxSuspension || 1000;
-
     var req = new XMLHttpRequest();
 
     req.onerror = function () {
@@ -180,8 +178,6 @@ window.CD = {
     url = args[0];
     options = args[1] || {};
 
-    options.maxSuspension = options.maxSuspension || 1000;
-
     var img = new Image();
     img.onload = function() {
       CD.capture();
@@ -201,7 +197,6 @@ window.CD = {
     callback = args.pop();
     url = args[0];
     options = args[1] || {};
-    options.maxSuspension = options.maxSuspension || 1000;
 
     var imagesLeft = urls.length;
     var imgs = [];


### PR DESCRIPTION
It gets confusing when various `CD` calls have their own timeouts and we also have webcrop timeouts. We still retain the option if you _really_ need to set a timeout, but by default if your call doesn't finish in time it'll just get killed by capturama after the crop timeout passes.