### PR TITLE
CD.whenAllResolved(function() {}) will call the function defined only…

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -104,6 +104,8 @@ window.CD = {
     CD._readyToCapture = true;
   },
 
+  _whenAllResolvedCB: function() {},
+
   suspend: function(maxSuspension) {
     CD._openCalls++;
     CD._readyToCapture = false;
@@ -129,12 +131,16 @@ window.CD = {
     }
 
     CD._readyToCapture = true;
+    CD._whenAllResolvedCB();
     if(typeof(MICapture) == 'undefined') {
       CD.log("now ready to capture");
     } else {
-      CD.$('body')[0].style.width = CD.$('body')[0].offsetWidth + 'px';
       MICapture.end();
     }
+  },
+
+  whenAllResolved: function(cb) {
+    CD._whenAllResolvedCB = cb;
   },
 
   getCORS: function(url, options, callback) {


### PR DESCRIPTION
… once after all CD dependencies have resolved

so usage would be:

```
CD.whenAllResolved(function() {
  $('#mi_size_container').removeClass('hidden');
});
```
