### PR TITLE
add x-mi-cbe header for consistent hashing

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -151,6 +151,7 @@ window.CD = {
 
     options.headers = options.headers || {};
     options.headers['x-reverse-proxy-ttl'] = options.corsCacheTime / 1000;
+    options.headers['x-mi-cbe'] = this._hashForRequest(url, options);
 
     return CD.get(url, options, callback);
   },
@@ -265,5 +266,15 @@ window.CD = {
 
   log: function(message) {
     console.log(message);
+  },
+
+  _hashForRequest: function(url, options) {
+    var str = url + JSON.stringify(options);
+    var hash = 0;
+    if (str.length === 0) return hash;
+    for (i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash) + str.charCodeAt(i) & 0xFFFFFFFF;
+    }
+    return hash.toString();
   }
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -244,6 +244,7 @@ QUnit.test("CD.getCORS", function(assert) {
 
   equal(requests.length, 1);
   equal(requests[0].requestHeaders['x-reverse-proxy-ttl'], 5);
+  equal(requests[0].requestHeaders['x-mi-cbe'], '-2134781906');
   equal(requests[0].requestHeaders['Accept'], 'application/json');
   equal(requests[0].method, 'GET');
   equal(requests[0].async, true);
@@ -265,6 +266,7 @@ QUnit.test("CD.getCORS without options", function(assert) {
 
   equal(requests.length, 1);
   equal(requests[0].requestHeaders['x-reverse-proxy-ttl'], 10);
+  equal(requests[0].requestHeaders['x-mi-cbe'], '2084411041');
   equal(requests[0].url, "http://cors.movableink.com/google.com/");
 
   xhr.restore();
@@ -291,6 +293,7 @@ QUnit.test("CD.getCORS with POST", function(assert) {
   equal(requests.length, 1);
   equal(requests[0].requestHeaders['x-reverse-proxy-ttl'], 5);
   equal(requests[0].requestHeaders['Accept'], 'application/json');
+  equal(requests[0].requestHeaders['x-mi-cbe'], '-1217831332');
   equal(requests[0].method, 'POST');
   equal(requests[0].async, true);
   equal(requests[0].requestBody, 'foobar');
@@ -314,4 +317,16 @@ QUnit.test("concurrent calls", function(assert) {
   CD.capture(); // 0 open calls
   equal(CD._readyToCapture, true, "sets readyToCapture");
   equal(CD._openCalls, 0, "zero open calls");
+});
+
+
+QUnit.test("_hashForRequest", function(assert) {
+  var hash = CD._hashForRequest("http://www.google.com", {"foo": "bar"});
+  equal(hash, "387990350");
+  hash = CD._hashForRequest("http://www.google.com", {"foo": "bar"});
+  equal(hash, "387990350");
+  var different = CD._hashForRequest("http://www.google.com", {"foo": "baz"});
+  equal(different, "387998038");
+  var another = CD._hashForRequest("http://www.example.com", {"foo": "baz"});
+  equal(another, "-164085129");
 });


### PR DESCRIPTION
This adds the `x-mi-cbe` header to all cropduster cors-proxy requests. With this header, the cors-proxy load balancer will always send a request with the same URL and options to the same cors machine. This should be a seamless upgrade with no changes required in apps (other than using this cropduster version) and no backwards compatibility issues.

@roger-rodriguez @kyle1980 @mnguyenmi @jgrossman-movable @mchesler 