### PR TITLE
runs callback for CD.get before trying to capture

### DIFF
--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -194,13 +194,13 @@ window.CD = {
     var req = new XMLHttpRequest();
 
     req.onerror = function () {
+      callback(null, this.status);
       CD.capture(msg);
       CD.log("XHR error for " + url);
-      callback(null, this.status);
     };
     req.onload = function() {
-      CD.capture(msg);
       callback(this.responseText, this.status);
+      CD.capture(msg);
     };
 
     req.open(options.method || 'GET', url, true);


### PR DESCRIPTION
This moves the callbacks for `CD.get` before the call to `CD.capture`

It seems like CD.get is not expecting content to be changed on the page in the callback, as it's trying to capture immediately. There's a usecase for Studio and Data Sources, where you fetch a Data Source's response data, and swap out the `src` for an image on the page with the value of a field in the response. Calling the callback after `CD.capture` causes Capturama to capture an image of the default content, and then calls capture again after the template calls `CD.getImage` on the new image src.