### PR TITLE
Exposing content-type response header as param in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Alternatively, for command-line tests:
 
 ## Changelog
 
+### 3.4.0
+  * Exposes the `content-type` response header within the callback of `CD.get()`.
+
 ### 3.3.0
   * Add support for `CD.waitForAsset()`. This API can be used to ensure that we will not render while the passed URL is in-flight.
 

--- a/lib/cropduster.js
+++ b/lib/cropduster.js
@@ -200,7 +200,8 @@ window.CD = {
     };
     req.onload = function() {
       CD.capture(msg);
-      callback(this.responseText, this.status);
+      var contentType = this.getResponseHeader('content-type');
+      callback(this.responseText, this.status, contentType);
     };
 
     req.open(options.method || 'GET', url, true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cropduster",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Library for building web pages for use with Movable Ink Web Crops",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
We currently give the callback function in `CD.get` the response and status as parameters. In order for https://github.com/movableink/studio-utility/pull/12 to work, we'll need to expose the content-type so that we can check the data by the response header.