### PR TITLE
Use window.fetch for network requests instead of XMLHttpRequest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015"],
+  "plugins": [
+    "add-module-exports"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-add-module-exports": "^0.1.0",
     "babel-preset-env": "^1.6.1",
     "fetch-mock": "^6.0.0-beta.2",
     "jquery": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.1",
+    "fetch-mock": "^6.0.0-beta.2",
     "jquery": "^3.2.1",
     "karma": "^1.7.1",
     "karma-babel-preprocessor": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "sinon": "^4.1.1",
     "uglifyjs-webpack-plugin": "^1.1.5",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.9.7",
-    "whatwg-fetch": "^2.0.3"
+    "webpack-dev-server": "^2.9.7"
   },
   "scripts": {
     "test": "node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "sinon": "^4.1.1",
     "uglifyjs-webpack-plugin": "^1.1.5",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.9.7"
+    "webpack-dev-server": "^2.9.7",
+    "whatwg-fetch": "^2.0.3"
   },
   "scripts": {
     "test": "node_modules/karma/bin/karma start",

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -1,5 +1,3 @@
-import 'whatwg-fetch';
-
 const CD = {
   CORS_PROXY_SERVER : "http://cors.movableink.com",
 

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -223,9 +223,10 @@ const CD = {
       deprecatedCallback(null);
 
       throw error;
-    }).finally(() => {
-      CD.resume(msg)
-    });
+    }).then(
+      () => CD.resume(msg),
+      () => CD.resume(msg)
+    );
   },
 
   getImage(url, options, callback) {

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -1,24 +1,27 @@
 const CD = {
   CORS_PROXY_SERVER : "http://cors.movableink.com",
 
-  $: function(selector, doc) {
+  $(selector, doc) {
     if(!doc) { doc = document; }
     return Array.prototype.slice.call(doc.querySelectorAll(selector));
   },
 
-  param: function(name) {
+  param(name) {
     return CD.params()[name];
   },
 
-  params: function(name) {
-    if(typeof(CD._urlParams) == "undefined") {
+  params(name) {
+    if (typeof(CD._urlParams) === 'undefined') {
       CD._urlParams = {};
-      var match;
-      var search = /([^&=]+)=?([^&]*)/g;
-      var query  = CD._searchString();
-      while (match = search.exec(query))
+      const search = /([^&=]+)=?([^&]*)/g;
+      const query  = CD._searchString();
+      let match = search.exec(query);
+      while (match) {
         CD._urlParams[decodeURIComponent(match[1])] = decodeURIComponent(match[2]);
+        match = search.exec(query);
+      }
     }
+
     if (name) {
       return CD._urlParams[name];
     } else {
@@ -26,11 +29,11 @@ const CD = {
     }
   },
 
-  _searchString: function() {
+  _searchString() {
     return window.location.search.substring(1);
   },
 
-  autofill: function() {
+  autofill() {
     CD.param("init"); // inits CD._urlParams
     Object.keys(CD._urlParams).forEach(function (key) {
       if (CD._urlParams[key] !== "undefined" && CD._urlParams[key].length > 0) {
@@ -41,25 +44,24 @@ const CD = {
     });
   },
 
-  throwError: function(msg) {
-    if(typeof(MICapture) == "undefined") {
+  throwError(msg) {
+    if (typeof MICapture === "undefined") {
       CD.log("Capturama error: " + msg);
     } else {
       MICapture.error(msg);
     }
   },
 
-  cancelRequest: function(msg) {
-    if(typeof(MICapture) == "undefined") {
+  cancelRequest(msg) {
+    if (typeof MICapture === "undefined") {
       CD.log("Request canceled: " + msg);
     } else {
       MICapture.cancel(msg);
     }
   },
 
-  setImageRedirect: function(imageUrl) {
-    var a = document.querySelector("#mi-redirect-image");
-    a = a || document.createElement('a');
+  setImageRedirect(imageUrl) {
+    const a = document.querySelector("#mi-redirect-image") || document.createElement('a');
 
     a.href = imageUrl;
     a.id = "mi-redirect-image";
@@ -70,24 +72,24 @@ const CD = {
     return a;
   },
 
-  setClickthrough: function(url) {
-    var a = document.querySelector("#mi_dynamic_link");
-    a = a || document.createElement('a');
+  setClickthrough(url) {
+    const a = document.querySelector("#mi_dynamic_link") || document.createElement('a');
+
     a.href = url;
     a.id = "mi_dynamic_link";
     a.style.display = "none";
+
     document.body.appendChild(a);
 
     return a;
   },
 
-  setExtraData: function(dataObject) {
-    var el = document.querySelector("#mi-data");
-    el = el || document.createElement('div');
+  setExtraData(dataObject) {
+    const el = document.querySelector("#mi-data") || document.createElement('div');
     el.id = "mi-data";
     el.style.display = "none";
 
-    var existingData;
+    let existingData;
     try {
       existingData = JSON.parse(el.getAttribute('data-mi-data')) || {};
     } catch(e) {
@@ -95,20 +97,21 @@ const CD = {
       existingData = {};
     }
 
-    for(var i in dataObject) {
-      if(dataObject.hasOwnProperty(i)) {
+    for (const i in dataObject) {
+      if (dataObject.hasOwnProperty(i)) {
         existingData[i] = dataObject[i];
       }
     }
+
     el.setAttribute('data-mi-data', JSON.stringify(existingData));
     document.body.appendChild(el);
 
     return el;
   },
 
-  proxyUrl: function(url) {
-    var a = document.createElement('a');
-    var port = "";
+  proxyUrl(url) {
+    const a = document.createElement('a');
+    let port = "";
     a.href = url;
 
     if (a.port === '0' || a.port === "") {
@@ -131,11 +134,11 @@ const CD = {
   // internal, do not modify
   _readyToCapture: true,
 
-  _reset: function() {
+  _reset() {
     CD._readyToCapture = true;
   },
 
-  pause: function(maxSuspension, msg) {
+  pause(maxSuspension, msg) {
     msg = msg || "manual suspension";
 
     if(maxSuspension) {
@@ -304,7 +307,7 @@ const CD = {
     });
   },
 
-  waitForAsset: function(assetUrl) {
+  waitForAsset(assetUrl) {
     if(typeof MICapture === "undefined") {
       CD.log("Wait for asset: " + assetUrl);
     } else {
@@ -312,11 +315,11 @@ const CD = {
     }
   },
 
-  log: function(message) {
+  log(message) {
     console.log(message);
   },
 
-  _hashForRequest: function(url, options) {
+  _hashForRequest(url, options) {
     var str = url + JSON.stringify(options);
     var hash = 0;
     if (str.length === 0) return hash;

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -1,3 +1,5 @@
+import 'whatwg-fetch';
+
 const CD = {
   CORS_PROXY_SERVER : "http://cors.movableink.com",
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ const importConfig = {
     library: 'cropduster',
     libraryTarget: 'umd',
     filename: 'cropduster.js',
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'dist')
   },
   ...defaultConfig
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,12 +10,7 @@ const defaultConfig = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['babel-preset-env']
-          }
-        }
+        use: ['babel-loader']
       }
     ]
   }
@@ -34,7 +29,7 @@ const importConfig = {
 const browserConfig = {
   output: {
     library: 'CD',
-    libraryTarget: 'window',
+    libraryTarget: 'var',
     filename: 'cropduster.browser.js',
     path: path.resolve(__dirname, 'dist')
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-module-exports@^0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.1.4.tgz#1a5b6d761ee1f663d845b4ea6878712de31c107a"
+  dependencies:
+    babel-template "^6.5.0"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -649,7 +655,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.5.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -4471,6 +4477,10 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+
+whatwg-fetch@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,13 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fetch-mock@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.0.0-beta.2.tgz#044a8aa74f0d0f9209122ac440c15f900fc84236"
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    path-to-regexp "^1.7.0"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2000,6 +2007,10 @@ glob-parent@^2.0.0:
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4478,10 +4478,6 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-whatwg-fetch@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"


### PR DESCRIPTION
Changes the implementation in #20 to use the `fetch` API instead of XMLHttpRequest
Includes the `whatwg-fetch` polyfill, since Capturama does not have `fetch` implemented. Loading this version of cropduster in a template will set the `window.fetch` function, making it usable outside of the cropduster functions.
  