### PR TITLE
Uses `fetch` instead of XMLHttpRequest in CD.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ console.log('If user clicks on the web crop, they will go to http://example.com'
 
 ## Changelog
 
-### 5.0.1
+### 5.1.0
   * CD.get uses the `fetch` API instead of XMLHttpRequest
 
 ### 5.0.0

--- a/README.md
+++ b/README.md
@@ -64,11 +64,19 @@ if (customerQuality === 'very-good') {
   CD.pause(tenSeconds, 'making bad customers wait for their email to load...');
 
   setTimeout(() => {
-    target.innerText = 'bad customers have to wait for their images';
     CD.resume();
+    target.innerText = 'bad customers have to wait for their images';
   }, 1000);
 }
 ```
+
+It is generally recommended to call CD.pause as the last thing before starting
+an asynchronous action, and CD.resume as the very first thing once that action
+has finished. If your asynchronous action completes successfully, but your
+callback runs some code before calling CD.resume again, then you run the risk of
+triggering a JavaScript error that stops execution of the current script. If
+CD.resume is not called after that first CD.pause, your image will eventually
+time out, as opposed to failing immediately.
 
 *NOTE:* Cropduster previously offered `CD.suspend` and `CD.capture` functions
 that achieved a similar goal. These functions have been replaced with `pause`

--- a/README.md
+++ b/README.md
@@ -212,9 +212,8 @@ console.log('If user clicks on the web crop, they will go to http://example.com'
 
 ## Testing
 
-    brew install phantomjs
-    npm install
-    npm test
+    yarn install
+    yarn run test
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ console.log('If user clicks on the web crop, they will go to http://example.com'
 
 ## Changelog
 
+### 5.0.1
+  * CD.get uses the `fetch` API instead of XMLHttpRequest
+
 ### 5.0.0
   * Compiles the app with Webpack and Babel down to ES5 with sourcemaps.
   * Returns Promises from CD.get, CD.getCORS, CD.getImage and CD.getImages

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.6.1",
+    "fetch-mock": "^6.0.0-beta.7",
     "jquery": "^3.2.1",
     "karma": "^1.7.1",
     "karma-babel-preprocessor": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cropduster",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Library for building web pages for use with Movable Ink Web Crops",
   "main": "src/cropduster.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cropduster",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Library for building web pages for use with Movable Ink Web Crops",
   "main": "dist/cropduster.js",
   "directories": {

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -226,7 +226,10 @@ const CD = {
         }
 
         return response.text().then(data => {
-          deprecatedCallback(data, response.status, response.contentType);
+          const status = response.status;
+          const contentType = response.headers.get('Content-Type');
+
+          deprecatedCallback(data, status, contentType);
 
           CD.resume(msg);
 
@@ -351,6 +354,17 @@ const CD = {
     }
 
     return hash.toString();
+  },
+
+  _optionsForFetch(options) {
+    return {
+      credentials: 'include',
+      redirect: 'follow',
+      headers: new Headers(options.headers || {}),
+      method: options.method || 'GET',
+      body: options.body,
+      mode: 'cors'
+    };
   }
 };
 

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -351,14 +351,19 @@ const CD = {
   },
 
   _optionsForFetch(options) {
-    return {
-      credentials: 'include',
+    const requestOptions = {
       redirect: 'follow',
       headers: new Headers(options.headers || {}),
       method: options.method || 'GET',
       body: options.body,
       mode: 'cors'
     };
+
+    if (!options.withoutCredentials) {
+      requestOptions.credentials = 'include';
+    }
+
+    return requestOptions;
   }
 };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -331,12 +331,6 @@ test("CD.get - request options", function(assert) {
 });
 
 test("CD.get - withoutCredentials option", function(assert) {
-  const xhr = useFakeXMLHttpRequest();
-  const requests = this.requests = [];
-  xhr.onCreate = function (xhr) {
-    requests.push(xhr);
-  };
-
   CD.get("http://google.com", {
     corsCacheTime: 5000,
     headers: {
@@ -352,9 +346,8 @@ test("CD.get - withoutCredentials option", function(assert) {
   assert.equal(lastRequest.headers.get('x-reverse-proxy-ttl'), null); // not automatically added
   assert.equal(lastRequest.headers.get('Accept'), 'application/json');
   assert.equal(lastRequest.method, 'GET');
-  assert.equal(lastRequest.credentials, 'include');
 
-  xhr.restore();
+  assert.notOk('credentials' in lastRequest, 'the request does not have a "credentials" option set');
 });
 
 test("CD.getCORS - request options", function(assert) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -345,13 +345,14 @@ test("CD.get - withoutCredentials option", function(assert) {
     withoutCredentials: true
   });
 
-  assert.equal(requests.length, 1);
-  assert.equal(requests[0].requestHeaders['x-reverse-proxy-ttl'], null); // not automatically added
-  assert.equal(requests[0].requestHeaders['Accept'], 'application/json');
-  assert.equal(requests[0].method, 'GET');
-  assert.equal(requests[0].async, true);
-  assert.equal(requests[0].withCredentials, false);
-  assert.equal(requests[0].url, "http://google.com");
+  const lastRequest = this.fakeServer.lastOptions();
+
+  assert.equal(this.fakeServer.calls.length, 1);
+  assert.equal(this.fakeServer.lastUrl(), "http://google.com");
+  assert.equal(lastRequest.headers.get('x-reverse-proxy-ttl'), null); // not automatically added
+  assert.equal(lastRequest.headers.get('Accept'), 'application/json');
+  assert.equal(lastRequest.method, 'GET');
+  assert.equal(lastRequest.credentials, 'include');
 
   xhr.restore();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,6 +1788,13 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fetch-mock@^6.0.0-beta.7:
+  version "6.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.0.0-beta.7.tgz#d30956fbc8c8844fb4cbbf342969f36931562b7e"
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    path-to-regexp "^1.7.0"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2004,6 +2011,10 @@ glob-parent@^2.0.0:
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"


### PR DESCRIPTION
Replaces the direct use of `XMLHttpRequest` with the [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

This PR depends on a capturama update here: https://github.com/movableink/capturama/pull/91/files