### PR TITLE
Import the minified ES5 bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cropduster",
   "version": "5.2.0",
   "description": "Library for building web pages for use with Movable Ink Web Crops",
-  "main": "src/cropduster.js",
+  "main": "dist/cropduster.js",
   "directories": {
     "test": "tests"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.0",
   "description": "Library for building web pages for use with Movable Ink Web Crops",
   "main": "dist/cropduster.js",
+  "module": "src/cropduster.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Currently Cropduster is not bundle-able via the `create-se-project` webpack config. Our build does not transpile the `src/cropduster.js` module.

Just a quick change to set the `main` property to `dist/cropduster.js` so that we can minify bundled project page JS.

Fixes #28 