### PR TITLE
Expose `response` in resolved CD.get Promise

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-const isDevelopment = process.env.NODE_ENV === 'development';
+const watchMode = process.env.KARMA_WATCH === 'true';
 
 module.exports = function(config) {
   config.set({
@@ -57,11 +57,11 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: isDevelopment,
+    autoWatch: watchMode,
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: !isDevelopment
+    singleRun: !watchMode
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+const isDevelopment = process.env.NODE_ENV === 'development';
+
 module.exports = function(config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -55,11 +57,11 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: isDevelopment,
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    singleRun: !isDevelopment
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "test": "yarn run karma start",
+    "develop-test": "NODE_ENV=development yarn run karma start",
     "build": "yarn run webpack",
     "build:dev": "NODE_ENV=development yarn run webpack --watch",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "yarn run karma start",
-    "develop-test": "NODE_ENV=development yarn run karma start",
+    "develop-test": "KARMA_WATCH=true yarn run karma start",
     "build": "yarn run webpack",
     "build:dev": "NODE_ENV=development yarn run webpack --watch",
     "prepublish": "npm run build"

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -215,7 +215,8 @@ const CD = {
         return {
           data,
           status,
-          contentType
+          contentType,
+          response
         };
       });
     }).then(

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -272,6 +272,24 @@ test("CD.get with promises and a successful response", function(assert) {
   });
 });
 
+test("CD.get yields the response object to the resolved promise", function(assert) {
+  const done = assert.async();
+
+  this.fakeServer.restore();
+  this.fakeServer = fetchMock.mock('*', {
+    body: 'ok',
+    headers: {
+      'Content-Type': 'text/html',
+      'Every-Thing-Is': 'awesome'
+    }
+  });
+
+  CD.get("http://callback.com").then(({ response }) => {
+    assert.equal(response.headers.get('every-thing-is'), 'awesome', 'the response headers are available');
+    done();
+  });
+});
+
 test("DEPRECATED - CD.get with callbacks and a failing response", function(assert) {
   this.fakeServer.restore();
   this.fakeServer.mock('*', 500);


### PR DESCRIPTION
A user may wish to get access to response headers from a requested resource. 

So, this adds the [`response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object to the resolved promise with `CD.get`. 