### PR TITLE
handle alternate charsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.DS_Store

--- a/src/cropduster.js
+++ b/src/cropduster.js
@@ -183,6 +183,20 @@ const CD = {
     return CD.get(url, options, callback);
   },
 
+  textForResponse(response) {
+    const type = response.headers.get('Content-Type');
+    const charsetRegex = /charset\=(.+)$/;
+    if (type && charsetRegex.test(type)) {
+      const [, encoding] = charsetRegex.exec(type);
+      return response.arrayBuffer().then((buffer) => {
+        const decoder = new TextDecoder(encoding); 
+        return decoder.decode(buffer);
+      });
+    } else {
+      return response.text();
+    }
+  },
+
   get(url, options = {}, callback) {
     if (typeof options === 'function') {
       callback = options;
@@ -206,7 +220,7 @@ const CD = {
         throw new Error(response.statusText); // A non-200 range status was returned
       }
 
-      return response.text().then(data => {
+      return this.textForResponse(response).then(data => {
         const status = response.status;
         const contentType = response.headers.get('Content-Type');
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -275,9 +275,32 @@ test("CD.get with promises and a successful response", function(assert) {
 test("CD.get handles alternate charsets", function(assert) {
   this.fakeServer.restore();
   fetchMock.mock('*', {
+    // \xec is euc-jp for: 狸
+    body: '\xec',
+    headers: {
+      'Content-Type': `text/html; charset=euc-jp`
+    }
+  });
+
+  const done = assert.async();
+
+  CD.get("http://callback.com", {
+    headers: {
+      'Accept': 'application/json'
+    }
+  }).then(({ data, status, contentType }) => {
+    assert.equal(data, '狸', 'resolves with a correctly decoded response');
+    assert.ok(contentType === 'text/html; charset=euc-jp', 'resolves with a content type');
+    done();
+  });
+});
+
+test("CD.get has sensible fallback for incorrect charsets", function(assert) {
+  this.fakeServer.restore();
+  fetchMock.mock('*', {
     body: 'ok',
     headers: {
-      'Content-Type': 'text/html; charset=euc-jp'
+      'Content-Type': 'text/html; charset=not-valid'
     }
   });
 
@@ -290,7 +313,7 @@ test("CD.get handles alternate charsets", function(assert) {
   }).then(({ data, status, contentType }) => {
     assert.ok(data === 'ok', 'resolves with a response');
     assert.ok(status === 200, 'resolves with a status');
-    assert.ok(contentType === 'text/html; charset=euc-jp', 'resolves with a content type');
+    assert.ok(contentType === 'text/html; charset=not-valid', 'resolves with a content type');
 
     assert.ok(true, 'the promise resolves successfully');
     done();
@@ -353,7 +376,6 @@ test("CD.get with promises and a failing response", function(assert) {
     }
   );
 });
-
 
 test("CD.get - request options", function(assert) {
   CD.get("http://google.com", {
@@ -485,3 +507,4 @@ test('CD.miCaptureFallback - without MICapture', function(assert) {
     () => { assert.ok(true, 'the second callback is called if MICapture is undefined'); }
   );
 });
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -272,6 +272,31 @@ test("CD.get with promises and a successful response", function(assert) {
   });
 });
 
+test("CD.get handles alternate charsets", function(assert) {
+  this.fakeServer.restore();
+  fetchMock.mock('*', {
+    body: 'ok',
+    headers: {
+      'Content-Type': 'text/html; charset=euc-jp'
+    }
+  });
+
+  const done = assert.async();
+
+  CD.get("http://callback.com", {
+    headers: {
+      'Accept': 'application/json'
+    }
+  }).then(({ data, status, contentType }) => {
+    assert.ok(data === 'ok', 'resolves with a response');
+    assert.ok(status === 200, 'resolves with a status');
+    assert.ok(contentType === 'text/html; charset=euc-jp', 'resolves with a content type');
+
+    assert.ok(true, 'the promise resolves successfully');
+    done();
+  });
+});
+
 test("CD.get yields the response object to the resolved promise", function(assert) {
   const done = assert.async();
 


### PR DESCRIPTION
Text with non-utf-8 encoding is not rendering properly in Studio review mode.

Here, if we have a charset in the Content-Type header,  we decode the response with the appropriate charset.
